### PR TITLE
Fix deploy: pass VITE_ env vars and opt into Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Build and Test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Build (production)
         run: npm run build
+        env:
+          VITE_LINKS_JSON_URL: ${{ vars.VITE_LINKS_JSON_URL }}
+          VITE_PROJECTS_JSON_URL: ${{ vars.VITE_PROJECTS_JSON_URL }}
 
       - uses: actions/configure-pages@v5
 


### PR DESCRIPTION
- Inject VITE_LINKS_JSON_URL and VITE_PROJECTS_JSON_URL from repo variables during Pages build (fixes missing env vars error)
- Opt into Node.js 24 for all Actions to silence deprecation warnings